### PR TITLE
Add cdk8s-mongo-sts & cdk8s-redis-sts to list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository curates the best [ckd8s](https://github.com/awslabs/cdk8s) resou
 > sort alphabetically by module name
 
 * [cdk8s-debore](https://github.com/toricls/cdk8s-debore) - Run your apps on Kubernetes cluster without bored YAMLing, powered by the cdk8s project 🚀
+* [cdk8s-aws-lb-controller-api-object)](https://github.com/opencdk8s/cdk8s-aws-lb-controller-api-object) - API object for AWS Load Balancer Controller
 * [cdk8s-docker](https://github.com/brennerm/cdk8s-docker) - inofficial Docker image for cdk8s
 * [cdk8s-mongo-sts](https://github.com/opencdk8s/cdk8s-mongo-sts) - CDK8s construct to create a replicated, and password protected MongoDB Kubernetes Statefulset 
 * [cdk8s-redis](https://github.com/eladb/cdk8s-redis) - Redis constructs for cdk8s

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository curates the best [ckd8s](https://github.com/awslabs/cdk8s) resou
 
 * [cdk8s-debore](https://github.com/toricls/cdk8s-debore) - Run your apps on Kubernetes cluster without bored YAMLing, powered by the cdk8s project 🚀
 * [cdk8s-docker](https://github.com/brennerm/cdk8s-docker) - inofficial Docker image for cdk8s
+* [cdk8s-mongo-sts](https://github.com/Hunter-Thompson/cdk8s-mongo-sts) - CDK8s construct to create a replicated, and password protected MongoDB Kubernetes Statefulset 
 * [cdk8s-redis](https://github.com/eladb/cdk8s-redis) - Redis constructs for cdk8s
 * [cdk8s-xray](https://github.com/mziyabo/cdk8s-xray) - AWS X-Ray constructs for cdk8s 
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository curates the best [ckd8s](https://github.com/awslabs/cdk8s) resou
 
 * [cdk8s-debore](https://github.com/toricls/cdk8s-debore) - Run your apps on Kubernetes cluster without bored YAMLing, powered by the cdk8s project 🚀
 * [cdk8s-docker](https://github.com/brennerm/cdk8s-docker) - inofficial Docker image for cdk8s
-* [cdk8s-mongo-sts](https://github.com/Hunter-Thompson/cdk8s-mongo-sts) - CDK8s construct to create a replicated, and password protected MongoDB Kubernetes Statefulset 
+* [cdk8s-mongo-sts](https://github.com/opencdk8s/cdk8s-mongo-sts) - CDK8s construct to create a replicated, and password protected MongoDB Kubernetes Statefulset 
 * [cdk8s-redis](https://github.com/eladb/cdk8s-redis) - Redis constructs for cdk8s
-* [cdk8s-redis-sts](https://github.com/Hunter-Thompson/cdk8s-redis-sts) - Redis statefulset constructs for cdk8s
+* [cdk8s-redis-sts](https://github.com/opencdk8s/cdk8s-redis-sts) - Redis statefulset constructs for cdk8s
 * [cdk8s-xray](https://github.com/mziyabo/cdk8s-xray) - AWS X-Ray constructs for cdk8s 
 
 ### Talks & Blog Posts

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository curates the best [ckd8s](https://github.com/awslabs/cdk8s) resou
 * [cdk8s-docker](https://github.com/brennerm/cdk8s-docker) - inofficial Docker image for cdk8s
 * [cdk8s-mongo-sts](https://github.com/Hunter-Thompson/cdk8s-mongo-sts) - CDK8s construct to create a replicated, and password protected MongoDB Kubernetes Statefulset 
 * [cdk8s-redis](https://github.com/eladb/cdk8s-redis) - Redis constructs for cdk8s
+* [cdk8s-redis-sts](https://github.com/Hunter-Thompson/cdk8s-redis-sts) - Redis statefulset constructs for cdk8s
 * [cdk8s-xray](https://github.com/mziyabo/cdk8s-xray) - AWS X-Ray constructs for cdk8s 
 
 ### Talks & Blog Posts


### PR DESCRIPTION
Uses [cvallance/mongo-k8s-sidecar](https://github.com/cvallance/mongo-k8s-sidecar) to run a replicated, and password protected MongoDB Kubernetes Statefulset.